### PR TITLE
Removed the fixes that were breaking tests

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,10 @@
+version = 1
+
+test_patterns = ["**/test_*.py"]
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -61,7 +61,7 @@ class CaseInsensitiveDict(MutableMapping):  # pragma: no cover
 
     """
     def __init__(self, data=None, **kwargs):
-        self._store = dict()
+        self._store = {}
         if data is None:
             data = {}
         self.update(data, **kwargs)

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -49,9 +49,9 @@ _ALL_ALLOWED = _UNRESERVED + _DELIMITERS
 _HEX_DIGITS = '0123456789ABCDEFabcdef'
 
 # This map construction is based on urllib's implementation
-_HEX_TO_BYTE = dict(((a + b).encode(), bytes([int(a + b, 16)]))
+_HEX_TO_BYTE = {(a + b).encode(): bytes([int(a + b, 16)])
                     for a in _HEX_DIGITS
-                    for b in _HEX_DIGITS)
+                    for b in _HEX_DIGITS}
 
 _PYPY = platform.python_implementation() == 'PyPy'
 

--- a/falcon/vendor/mimeparse/mimeparse.py
+++ b/falcon/vendor/mimeparse/mimeparse.py
@@ -98,7 +98,7 @@ def quality_and_fitness_parsed(mime_type, parsed_ranges):
         if type_match and subtype_match:
 
             # 100 points if the type matches w/o a wildcard
-            fitness = type == target_type and 100 or 0
+            fitness = 100 if type == target_type else 0
 
             # 10 points if the subtype matches w/o a wildcard
             fitness += subtype == target_subtype and 10 or 0
@@ -181,7 +181,7 @@ def best_match(supported, header):
         pos += 1
     weighted_matches.sort()
 
-    return weighted_matches[-1][0][0] and weighted_matches[-1][2] or ''
+    return weighted_matches[-1][2] if weighted_matches[-1][0][0] else ''
 
 
 def _filter_blank(i):

--- a/tests/asgi/test_ws.py
+++ b/tests/asgi/test_ws.py
@@ -690,7 +690,7 @@ async def test_unexpected_param(conductor):
     b'DEADBEEF',
     ['SIS508'],
     [],
-    tuple(),
+    (),
     {},
 
     'OK',  # control


### PR DESCRIPTION
### Summary of fixes
- ~~Change methods not using its bound instance to staticmethods~~
- use literal syntax instead of function calls to create data structure
- ~~remove assert statement from non-test files~~
- ~~refactor unnecessary 'else' / 'elif' when 'if' block has a 'return' statement~~ 
- replace ternary syntax with if expression
- ~~remove methods with unnecessary super delegation~~
- remove unnecessary generator

Autopep8 removed from `.deepsource.toml`
